### PR TITLE
Fix preview fail if atom-html-preview installed

### DIFF
--- a/lib/graphviz-preview.coffee
+++ b/lib/graphviz-preview.coffee
@@ -17,7 +17,7 @@ module.exports =
       catch error
         return
 
-      return unless protocol is 'html-preview:'
+      return unless protocol is 'graphviz-preview:'
 
       try
         pathname = decodeURI(pathname) if pathname
@@ -33,7 +33,7 @@ module.exports =
     editor = atom.workspace.getActiveTextEditor()
     return unless editor?
 
-    uri = "html-preview://editor/#{editor.id}"
+    uri = "graphviz-preview://editor/#{editor.id}"
 
     previewPane = atom.workspace.paneForURI(uri)
     if previewPane


### PR DESCRIPTION
If atom-html-preview is installed, preview will fail.

So I modify the protocol 'html-preview' to 'graphviz-preview' to fix preview issue.
